### PR TITLE
Directory path of library install name removed

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -216,6 +216,8 @@ class LibffiConan(ConanFile):
             if autotools.host and "x86-" in autotools.host:
                 autotools.host = autotools.host.replace("x86", "i686")
         with self._create_auto_tools_environment(autotools):
+            if self.settings.os == "Macos":
+                tools.replace_in_file(os.path.join(self.source_folder, self._source_subfolder, "configure"), r"-install_name \$rpath/", "-install_name ")
             autotools.configure(configure_dir=os.path.join(self.source_folder, self._source_subfolder),
                                 build=build,
                                 host=host,


### PR DESCRIPTION
Currently library install name after packaging is something like `/Users/travis/.conan/data/libffi/3.2.1/bincrafters/stable/package/ea598ec51f506a4c0ce579fe1e9cbc6299458ebb/lib/libffi.6.dylib` and therefore it is impossible to link this library without applying `install_name_tool -id ...`. It seems that default conan approach is to remove directory part of library install name and leave only library name, so this patch removes directory part of install name in `configure` script.