### PR TITLE
Added patches to fix deprecated arm instruction when building with clang >=7.0

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -145,6 +145,16 @@ class LibffiConan(ConanFile):
         if self.settings.os == "Macos":
             tools.replace_in_file(configure_path, r"-install_name \$rpath/", "-install_name ")
 
+        if self.settings.compiler == "clang" and float(str(self.settings.compiler.version)) >= 7.0:
+            # https://android.googlesource.com/platform/external/libffi/+/ca22c3cb49a8cca299828c5ffad6fcfa76fdfa77
+            sysv_s_src = os.path.join(self._source_subfolder, "src", "arm", "sysv.S")
+            tools.replace_in_file(sysv_s_src, "fldmiad", "vldmia")
+            tools.replace_in_file(sysv_s_src, "fstmiad", "vstmia")
+            tools.replace_in_file(sysv_s_src, "fstmfdd\tsp!,", "vpush")
+
+            # https://android.googlesource.com/platform/external/libffi/+/7748bd0e4a8f7d7c67b2867a3afdd92420e95a9f
+            tools.replace_in_file(sysv_s_src, "stmeqia", "stmiaeq")
+                
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC


### PR DESCRIPTION
It seems that there is an issue when building with `clang` >=7.0 for `arm` arch that some instruction is deprecated in new `clang`. This PR applies patches from android repo:
https://android.googlesource.com/platform/external/libffi/+/ca22c3cb49a8cca299828c5ffad6fcfa76fdfa77
https://android.googlesource.com/platform/external/libffi/+/7748bd0e4a8f7d7c67b2867a3afdd92420e95a9f